### PR TITLE
Replace python-etcd with bash+etcdctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,17 @@ FROM ubuntu:14.04
 MAINTAINER Jason Wilder jwilder@litl.com
 
 RUN apt-get update
-RUN apt-get install -y wget python python-pip python-dev libssl-dev libffi-dev bash
-
-RUN mkdir /app
-WORKDIR /app
+RUN apt-get install -y wget bash
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/0.3.3/docker-gen-linux-amd64-0.3.3.tar.gz
 RUN tar xvzf docker-gen-linux-amd64-0.3.3.tar.gz -C /usr/local/bin
 
-RUN pip install python-etcd
+RUN wget https://github.com/coreos/etcd/releases/download/v2.0.12/etcd-v2.0.12-linux-amd64.tar.gz
+RUN tar xvzf etcd-v2.0.12-linux-amd64.tar.gz && mv etcd-v2.0.12-linux-amd64/etcdctl /usr/local/bin
 
-ADD . /app
+RUN mkdir /app
+ADD etcd.tmpl /app/
 
 ENV DOCKER_HOST unix:///var/run/docker.sock
 
-CMD docker-gen -interval 10 -watch -notify "python /tmp/register.py" etcd.tmpl /tmp/register.py
+CMD docker-gen -interval 10 -watch -notify "bash /tmp/register.sh" /app/etcd.tmpl /tmp/register.sh

--- a/etcd.tmpl
+++ b/etcd.tmpl
@@ -1,6 +1,8 @@
 
 #!/bin/bash
 
+test -z "$ETCD_HOST" && echo "ETCD_HOST not set" && exit 1
+
 test -z "$(echo $ETCD_HOST | cut -d':' -f2)" && ETCD_HOST="$ETCD_HOST:4001"
 
 alias etcdctl='etcdctl -C http://$ETCD_HOST --no-sync'

--- a/etcd.tmpl
+++ b/etcd.tmpl
@@ -5,7 +5,7 @@ test -z "$ETCD_HOST" && echo "ETCD_HOST not set" && exit 1
 
 test -z "$(echo $ETCD_HOST | cut -d':' -f2)" && ETCD_HOST="$ETCD_HOST:4001"
 
-alias etcdctl='etcdctl -C http://$ETCD_HOST --no-sync'
+etcdctl() { etcdctl -C http://$ETCD_HOST --no-sync $@; }
 
 etcdctl ls /backends || etcdctl mkdir /backends
 

--- a/etcd.tmpl
+++ b/etcd.tmpl
@@ -1,27 +1,11 @@
 
-#!/usr/bin/python
+#!/bin/bash
 
-import etcd
-import sys
-from urlparse import urlparse
+test -z "$(echo $ETCD_HOST | cut -d':' -f2)" && ETCD_HOST="$ETCD_HOST:4001"
 
-etcd_host = "{{ .Env.ETCD_HOST }}"
-if not etcd_host:
-    print "ETCD_HOST not set"
-    sys.exit(1)
+alias etcdctl='etcdctl -C http://$ETCD_HOST --no-sync'
 
-port = 4001
-host = etcd_host
-
-if ":" in etcd_host:
-    host, port = etcd_host.split(":")
-
-client = etcd.Client(host=host, port=int(port))
-
-try:
-    backends = client.read("/backends")
-except KeyError:
-    client.write("/backends", None, dir=True)
+etcdctl ls /backends || etcdctl mkdir /backends
 
 {{ $local := . }}
 {{range $key, $value := .}}
@@ -32,8 +16,8 @@ except KeyError:
 {{ if $address.HostPort}}
 # {{ $value.Name }}
 
-client.write("/backends/{{ $value.Image.Repository}}/{{printf "%.*s" 12 $value.ID}}", "{{ $local.Env.HOST_IP }}:{{ $address.HostPort }}", ttl=15)
-client.write("/backends/{{ $value.Image.Repository}}/port", "{{ $address.Port }}", ttl=15)
+etcdctl set --ttl 15 "/backends/{{ $value.Image.Repository}}/{{printf "%.*s" 12 $value.ID}}" "{{ $local.Env.HOST_IP }}:{{ $address.HostPort }}"
+etcdctl set --ttl 15 "/backends/{{ $value.Image.Repository}}/port" "{{ $address.Port }}"
 
 {{ end }}
 {{ end }}

--- a/etcd.tmpl
+++ b/etcd.tmpl
@@ -5,7 +5,7 @@ test -z "$ETCD_HOST" && echo "ETCD_HOST not set" && exit 1
 
 test -z "$(echo $ETCD_HOST | cut -d':' -f2)" && ETCD_HOST="$ETCD_HOST:4001"
 
-etcdctl() { etcdctl -C http://$ETCD_HOST --no-sync $@; }
+etcdctl() { /usr/local/bin/etcdctl -C http://$ETCD_HOST --no-sync $@; }
 
 etcdctl ls /backends || etcdctl mkdir /backends
 


### PR DESCRIPTION
This removes unnecessary dependency bundle of python and etcd library. Plus, our image is down to ~240MB from ~410MB.
